### PR TITLE
Add CSS and SASS support

### DIFF
--- a/client/next.config.js
+++ b/client/next.config.js
@@ -1,0 +1,4 @@
+const withCss = require("@zeit/next-css");
+const withSass = require("@zeit/next-sass");
+
+module.exports = withSass(withCss({}));

--- a/client/package.json
+++ b/client/package.json
@@ -12,7 +12,10 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "@zeit/next-css": "^1.0.1",
+    "@zeit/next-sass": "^1.0.1",
     "next": "^9.2.1",
+    "node-sass": "^4.13.1",
     "react": "^16.12.0",
     "react-dom": "^16.12.0"
   }


### PR DESCRIPTION
By default, Next.js only supports CSS-in-JS, not importing from a `.css`, `.sass`, or `.scss` file. This PR adds [@zeit/next-css](https://www.npmjs.com/package/@zeit/next-css) and [@zeit/next-sass](https://www.npmjs.com/package/@zeit/next-sass) to allow importing from these files.