### PR TITLE
Custom scrollbar

### DIFF
--- a/client/components/PhaseDetailEdit.jsx
+++ b/client/components/PhaseDetailEdit.jsx
@@ -75,7 +75,7 @@ export default function PhaseDetailEdit(props) {
         </div>
         <hr />
         {details?.map((detail, index) => (
-          <div className="edit-detail">
+          <div className="edit-detail" key={index}>
             <div className="d-flex justify-content-between">
               <Label>Name</Label>
               <span

--- a/client/public/styles/style.scss
+++ b/client/public/styles/style.scss
@@ -3,10 +3,31 @@
 @import url("https://fonts.googleapis.com/css2?family=Lato&display=swap");
 @import url("https://fonts.googleapis.com/css2?family=Lato:wght@400;700&display=swap");
 
+$yellow: #ffcc66;
+
 body {
   font-family: "Source Sans Pro", sans-serif;
   font-family: "Open Sans", sans-serif;
 }
+
+body::-webkit-scrollbar {
+  width: 0.8rem;
+}
+
+body::-webkit-scrollbar-track {
+  background: hsla(0, 0, 0, 0);
+}
+
+body::-webkit-scrollbar-thumb {
+  background-color: $yellow;
+  border-radius: 0.4rem;
+  box-shadow: 1px 1px 2px 0 hsla(0, 0, 0, 0.2);
+}
+
+body::-webkit-scrollbar-thumb:hover {
+  box-shadow: 1px 1px 4px 0 hsla(0, 0, 0, 0.4);
+}
+
 .page-transition-enter {
   opacity: 0;
 }


### PR DESCRIPTION
Changes default scrollbar to a rounded one using the yellow from the color palette. Scrollbar has a barely visible shadow that darkens/expands slightly upon hover for visual clarity.

![image](https://user-images.githubusercontent.com/32147742/81880260-a36e6780-9552-11ea-86c2-714e640d5e03.png)

Notes:
- Custom scrollbar will not appear in IE, Edge (pre-Chromium), and Firefox
- Ignore the yellow-on-yellow on the home page, #81 will change the homepage background color
- Scrollbar box shadows are in px values due to dealing with tiny sizes

Side effects:
 - Fixes a lint error that somehow occurs on GH Actions but not locally (maybe a versioning thing)