### PR TITLE
Enable GitHub Action caching

### DIFF
--- a/.github/workflows/api.yaml
+++ b/.github/workflows/api.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: Set up Node
         uses: actions/setup-node@v1
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: Set up Node
         uses: actions/setup-node@v1

--- a/.github/workflows/api.yaml
+++ b/.github/workflows/api.yaml
@@ -6,25 +6,49 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - name: Check out repository
+        uses: actions/checkout@v1
+
+      - name: Set up Node
+        uses: actions/setup-node@v1
         with:
           node-version: 12
-      - name: npm run format
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-cache
+
+      - name: Install dependencies
         working-directory: ./api
-        run: |
-          npm install
-          npm run format:check
+        run: npm install
+
+      - name: Check formatting
+        working-directory: ./api
+        run: npm run format:check
 
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - name: Check out repository
+        uses: actions/checkout@v1
+
+      - name: Set up Node
+        uses: actions/setup-node@v1
         with:
           node-version: 12
-      - name: npm run lint
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-cache
+
+      - name: Install dependencies
         working-directory: ./api
-        run: |
-          npm install
-          npm run lint
+        run: npm install
+
+      - name: Run linter
+        working-directory: ./api
+        run: npm run lint

--- a/.github/workflows/api.yaml
+++ b/.github/workflows/api.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Cache dependencies
         uses: actions/cache@v2
         with:
-          path: node_modules
+          path: api/node_modules
           key: ${{ runner.os }}-cache
 
       - name: Install dependencies
@@ -42,7 +42,7 @@ jobs:
       - name: Cache dependencies
         uses: actions/cache@v2
         with:
-          path: node_modules
+          path: api/node_modules
           key: ${{ runner.os }}-cache
 
       - name: Install dependencies

--- a/.github/workflows/client.yaml
+++ b/.github/workflows/client.yaml
@@ -17,7 +17,7 @@ jobs:
       - name: Cache dependencies
         uses: actions/cache@v2
         with:
-          path: node_modules
+          path: client/node_modules
           key: ${{ runner.os }}-cache
 
       - name: Install dependencies
@@ -42,7 +42,7 @@ jobs:
       - name: Cache dependencies
         uses: actions/cache@v2
         with:
-          path: node_modules
+          path: client/node_modules
           key: ${{ runner.os }}-cache
 
       - name: Install dependencies
@@ -67,7 +67,7 @@ jobs:
       - name: Cache dependencies
         uses: actions/cache@v2
         with:
-          path: node_modules
+          path: client/node_modules
           key: ${{ runner.os }}-cache
 
       - name: Install dependencies

--- a/.github/workflows/client.yaml
+++ b/.github/workflows/client.yaml
@@ -6,41 +6,77 @@ jobs:
   format:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - name: Check out repository
+        uses: actions/checkout@v1
+
+      - name: Set up Node
+        uses: actions/setup-node@v1
         with:
           node-version: 12
-      - name: npm run format
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-cache
+
+      - name: Install dependencies
         working-directory: ./client
-        run: |
-          npm install
-          npm run format:check
+        run: npm install
+
+      - name: Check formatting
+        working-directory: ./client
+        run: npm run format:check
 
   lint:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+      - name: Check out repository
+        uses: actions/checkout@v1
+
+      - name: Set up Node
+        uses: actions/setup-node@v1
         with:
           node-version: 12
-      - name: npm run lint
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-cache
+
+      - name: Install dependencies
         working-directory: ./client
-        run: |
-          npm install
-          npm run lint
+        run: npm install
+
+      - name: Run linter
+        working-directory: ./client
+        run: npm run lint
 
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v1
-      - uses: actions/setup-node@v1
+     - name: Check out repository
+        uses: actions/checkout@v1
+
+      - name: Set up Node
+        uses: actions/setup-node@v1
         with:
           node-version: 12
-      - name: npm run build
+
+      - name: Cache dependencies
+        uses: actions/cache@v2
+        with:
+          path: node_modules
+          key: ${{ runner.os }}-cache
+
+      - name: Install dependencies
         working-directory: ./client
-        run: |
-          npm install
-          npm run build
+        run: npm install
+      
+      - name: Build application
+        working-directory: ./client
+        run: npm run build
         env:
           FIREBASE_APIKEY: ${{ secrets.FIREBASE_APIKEY }}
           AUTH_DOMAIN: ${{ secrets.AUTH_DOMAIN }}

--- a/.github/workflows/client.yaml
+++ b/.github/workflows/client.yaml
@@ -56,7 +56,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-     - name: Check out repository
+      - name: Check out repository
         uses: actions/checkout@v1
 
       - name: Set up Node
@@ -73,7 +73,7 @@ jobs:
       - name: Install dependencies
         working-directory: ./client
         run: npm install
-      
+
       - name: Build application
         working-directory: ./client
         run: npm run build

--- a/.github/workflows/client.yaml
+++ b/.github/workflows/client.yaml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: Set up Node
         uses: actions/setup-node@v1
@@ -32,7 +32,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: Set up Node
         uses: actions/setup-node@v1
@@ -57,7 +57,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v1
+        uses: actions/checkout@v2
 
       - name: Set up Node
         uses: actions/setup-node@v1

--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ FateMaker will be a platform designed to guide students through solving sustaina
 
 Kids Save Ocean is an environmental nonprofit aiming to empower children to have their voices heard in the discussion about the planet's environment. So far, their efforts have been focused on developing FateChanger, an app which educates and allows students to interact with their local government and other institutions to bring about policy change. With FateChanger launching in early 2020, FateMaker will be Kids Save Ocean's next application, with initial release targeted for Summer 2020.
 
-<h2 align="center">The Team</h2>
+<h2 align="center">The Team (Spring 2020)</h2>
 
 <table align="center">
   <tr>

--- a/auth-server/package.json
+++ b/auth-server/package.json
@@ -19,7 +19,7 @@
     "eslint": "^5.15.1",
     "eslint-config-airbnb-base": "^13.1.0",
     "eslint-plugin-import": "^2.16.0",
-    "express": "^4.16.4",
+    "express": "^4.17.1",
     "express-jwt": "^5.3.1",
     "express-validator": "^5.3.1",
     "googleapis": "^39.2.0",

--- a/client/package.json
+++ b/client/package.json
@@ -52,7 +52,7 @@
     "react-loader-spinner": "^3.1.14",
     "react-player": "^1.15.2",
     "react-select": "^3.1.0",
-    "reactstrap": "^8.4.1",
+    "reactstrap": "^8.5.1",
     "svg-loaders-react": "^2.2.1"
   },
   "devDependencies": {


### PR DESCRIPTION
Sets up a cache to reduce `npm install` times on GitHub Actions.

`client / build` and the Vercel action will remain the limiting factors as the build step is both the longest step and is unchanged, but other actions will be significantly faster. Improvements are a function of dependency size, so as the application grows caching will see increased benefits - this also explains the larger benefits for the frontend over the backend.

Note - other changed files are to trigger actions and do not result in functionality changes.

## `api`

### Before
![image](https://user-images.githubusercontent.com/32147742/86078765-71f32200-ba54-11ea-9403-585d47acf6b3.png)

### After
![image](https://user-images.githubusercontent.com/32147742/86078801-846d5b80-ba54-11ea-8f94-5105ff50b4ca.png)

## `client`

### Before
![image](https://user-images.githubusercontent.com/32147742/86078858-a49d1a80-ba54-11ea-96bb-9e86cd082588.png)

### After
![image](https://user-images.githubusercontent.com/32147742/86078893-baaadb00-ba54-11ea-8788-27703929ede1.png)
